### PR TITLE
Fix variable names in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -45,8 +45,7 @@ Customizing the scroll bar is a bit tricky because the width is not
 only determined by CSS.  The minor mode ~custom-css-scroll-bar-mode~
 simplifies modifying the scroll-bar appearance.
 
-Customize ~on-demand-scroll-bar-custom-css~ and
-~on-demand-scroll-bar-custom-css-width~.
+Customize ~custom-css-scroll-bar-css~ and ~custom-css-scroll-bar-width~.
 
 [[./img/img1.png]]
 


### PR DESCRIPTION
Variables mentioned in README.org for scroll-bar customization don't match the actual variables.